### PR TITLE
updates focused on internationalization (i18n) improvements, canonical URL handling, and minor refactoring for better code readability and maintainability

### DIFF
--- a/app/content/projects/portfolio.ts
+++ b/app/content/projects/portfolio.ts
@@ -5,7 +5,7 @@ export const project = {
 		'projects.portfolio.highlights.cloudflareWorkers',
 		'projects.portfolio.highlights.i18n',
 	],
-	link: 'https://clausaas.dev',
+	link: 'https://claushaas.dev',
 	technologies: [
 		'React',
 		'React Native',

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -5,8 +5,22 @@ import { I18nextProvider } from 'react-i18next';
 import { HydratedRouter } from 'react-router/dom';
 import { initI18Next } from './i18n/i18n';
 
+function getInitialLanguage() {
+	const script = document.getElementById('initial-i18n-language');
+	if (script) {
+		try {
+			const { language } = JSON.parse(script.textContent || '{}');
+			return language;
+		} catch {
+			return undefined;
+		}
+	}
+	return undefined;
+}
+
 async function main() {
-	await initI18Next(i18next);
+	const initialLanguage = getInitialLanguage();
+	await initI18Next(i18next, initialLanguage);
 
 	startTransition(() => {
 		hydrateRoot(

--- a/app/i18n/i18n.ts
+++ b/app/i18n/i18n.ts
@@ -58,7 +58,7 @@ export const initI18Next = async (i18next: typeof i18n, language?: string) => {
 		fallbackLng: 'en',
 		initImmediate: true,
 		interpolation: { escapeValue: false },
-		keySeparator: false,
+		// keySeparator removido para permitir navegação em objetos aninhados
 		load: 'languageOnly',
 		react: { useSuspense: false },
 		supportedLngs: supportedLanguages,

--- a/app/i18n/i18n.ts
+++ b/app/i18n/i18n.ts
@@ -72,14 +72,18 @@ export const initI18Next = async (i18next: typeof i18n, language?: string) => {
 		options.defaultNS = 'namespace1';
 	}
 
-	// then we add the configuration used only client-side
+	// then we add the configuration usada apenas no client
 	if (isBrowser) {
-		// here we configure the path for our JSON filas with the localized messages
 		options.backend = { loadPath: '/locales/{{lng}}.json' };
-		// and here we set what to use as cache for the language detection
-		options.detection = { caches: ['cookie'] };
-		// and we tell i18next to use the language detector and http api plugins
 		i18next.use(LanguageDetector).use(HttpApi);
+		const cookieOptions = { path: '/', sameSite: 'lax' as const };
+		if (language) {
+			// Se idioma foi passado explicitamente, não ativa detecção, mas permite setar cookie
+			options.lng = language;
+			options.detection = { caches: ['cookie'], cookieOptions, order: [] };
+		} else {
+			options.detection = { caches: ['cookie'], cookieOptions };
+		}
 	}
 
 	// now we tell i18next to use the React plunig and wee initialize it with our options

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -52,11 +52,14 @@ export const links: Route.LinksFunction = () => [
 
 export const loader = ({ request }: LoaderFunctionArgs) => {
 	const language = detectLanguage(request);
-	return { language };
+	const canonicalUrl = request.url;
+	return { canonicalUrl, language };
 };
 
 export function Layout({ children }: { children: React.ReactNode }) {
-	const language = useLoaderData<typeof loader>().language;
+	const loaderData = useLoaderData<typeof loader>();
+	const language = loaderData?.language ?? 'pt';
+	const canonicalUrl = loaderData?.canonicalUrl;
 	const isBot = useIsBot();
 
 	return (
@@ -86,10 +89,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 				<meta content="true" name="HandheldFriendly" />
 				<meta content="strict-origin-when-cross-origin" name="referrer" />
 				<meta content={language} httpEquiv="Content-Language" />
-				<link
-					href={typeof window !== 'undefined' ? window.location.href : ''}
-					rel="canonical"
-				/>
+				{canonicalUrl && <link href={canonicalUrl} rel="canonical" />}
 				{/* Open Graph */}
 				<meta content="Claus Haas Ltda." property="og:title" />
 				<meta
@@ -97,10 +97,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 					property="og:description"
 				/>
 				<meta content="website" property="og:type" />
-				<meta
-					content={typeof window !== 'undefined' ? window.location.href : ''}
-					property="og:url"
-				/>
+				{canonicalUrl && <meta content={canonicalUrl} property="og:url" />}
 				<meta content="/android-chrome-512x512.png" property="og:image" />
 				{/* Twitter Card */}
 				<meta content="summary_large_image" name="twitter:card" />
@@ -112,6 +109,10 @@ export function Layout({ children }: { children: React.ReactNode }) {
 				<meta content="/android-chrome-512x512.png" name="twitter:image" />
 				<Meta />
 				<Links />
+				{/* Injeção do idioma inicial para o client sincronizar com SSR */}
+				<script id="initial-i18n-language" type="application/json">
+					{JSON.stringify({ language })}
+				</script>
 			</head>
 			<body className="m-auto h-fit max-w-4xl space-y-16 bg-slate-1 px-4 dark:bg-slatedark-1">
 				{children}

--- a/app/ui/components/project-card.tsx
+++ b/app/ui/components/project-card.tsx
@@ -48,8 +48,8 @@ export default function ProjectCard({ project }: ProjectCardProps) {
 			)}
 			{project.highlights && project.highlights.length > 0 && (
 				<ul className="mb-2 list-disc pl-5 text-sky-11 dark:text-skydark-11">
-					{project.highlights.map((destaque) => (
-						<li key={destaque}>{t(destaque)}</li>
+					{project.highlights.map((highlight) => (
+						<li key={highlight}>{t(highlight)}</li>
 					))}
 				</ul>
 			)}

--- a/app/ui/components/project-card.tsx
+++ b/app/ui/components/project-card.tsx
@@ -55,7 +55,9 @@ export default function ProjectCard({ project }: ProjectCardProps) {
 			)}
 			{project.link ? (
 				<a
-					aria-label={t('project.seeMoreAria', { title: project.title })}
+					aria-label={t('project.seeMoreAria', {
+						title: t(project.title ?? ''),
+					})}
 					className="text-sky-10 underline hover:opacity-80"
 					href={project.link}
 					rel="noopener noreferrer"

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -79,6 +79,7 @@
 			"title": "Yoga em Movimento"
 		}
 	},
+	"projects.budgetPal.title": "budgetPal",
 	"projects.listAria": "Project list",
 	"projects.next": "Next",
 	"projects.nextAria": "Next project",


### PR DESCRIPTION
This pull request introduces several updates focused on internationalization (i18n) improvements, canonical URL handling, and minor refactoring for better code readability and maintainability. The most significant changes include adding support for passing the initial language from server to client, improving canonical URL generation, and refining translation keys and mappings.

### Internationalization (i18n) Enhancements:
* Added a `getInitialLanguage` function to extract the initial language from a script tag in the DOM, and updated `initI18Next` to accept this initial language for synchronization between server-side rendering (SSR) and the client. (`app/entry.client.tsx`, `app/i18n/i18n.ts`) [[1]](diffhunk://#diff-c5698d7b301af51f1573ea4b61bbd1878710472917906bf4f779a64fc3055615R8-R23) [[2]](diffhunk://#diff-3c47283de8b6d1e5eeee69cf62542e20b08276dbaeb32b761c84af5c31fea66cL61-R61) [[3]](diffhunk://#diff-3c47283de8b6d1e5eeee69cf62542e20b08276dbaeb32b761c84af5c31fea66cL75-R86)
* Injected the initial language into the HTML head during SSR to ensure the client can synchronize i18n state with the server. (`app/root.tsx`)

### Canonical URL Handling:
* Updated the `loader` function to include the canonical URL in its return value, and modified the `<Layout>` component to use this canonical URL for `<link rel="canonical">` and Open Graph `<meta>` tags. (`app/root.tsx`) [[1]](diffhunk://#diff-4133eb55408b25b35b8e07c696a9dfc97b741c555d7407e8c86d0845e5eecc28L55-R62) [[2]](diffhunk://#diff-4133eb55408b25b35b8e07c696a9dfc97b741c555d7407e8c86d0845e5eecc28L89-R100)

### Code Refactoring:
* Replaced Portuguese variable names (e.g., `destaque`) with English equivalents (e.g., `highlight`) for consistency across the codebase. (`app/ui/components/project-card.tsx`)
* Updated translation key mappings and added a new translation key for a project title. (`public/locales/en.json`)

### Minor Fixes:
* Corrected the portfolio project link URL from `https://clausaas.dev` to `https://claushaas.dev`. (`app/content/projects/portfolio.ts`)